### PR TITLE
remove path in compile task for windows support.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ var jasmine = require('gulp-jasmine');
 var reporters = require('jasmine-reporters');
 
 gulp.task('compile', function(cb) {
-  exec('node_modules/typescript/bin/tsc', function (err, stdout, stderr) {
+  exec('tsc', function (err, stdout, stderr) {
     if (stdout) console.log(stdout);
     if (stderr) console.log(stderr);
     cb(err);


### PR DESCRIPTION
I am not sure if this will work on unix based systems - my understanding is it depends on how the enviroment is set up. If you know of of a better way of handling this for windows support it would be great to hear. cheers D
